### PR TITLE
Fix missing 'get_imp_inner' with specific feature combination

### DIFF
--- a/src/imp/avx512.rs
+++ b/src/imp/avx512.rs
@@ -34,7 +34,7 @@ fn get_imp_inner() -> Option<Adler32Imp> {
 
 #[inline]
 #[cfg(all(
-  not(all(target_feature = "avx512f", target_feature = "avx512bw")),
+  not(all(feature = "nightly", target_feature = "avx512f", target_feature = "avx512bw")),
   not(all(
     feature = "std",
     feature = "nightly",


### PR DESCRIPTION
If compiled without the "nightly" feature but with the indicated avx512 flags, then previously there would be an error that the rustc "cannot find function `get_imp_inner` in this scope".

I believe that this is causing CI failures for [image-rs/image](https://github.com/image-rs/image) like [this one](https://github.com/image-rs/image/actions/runs/4395761726/jobs/7697784134).