### PR TITLE
add force-scalar feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ default = ["std", "const-generics"]
 std = []
 nightly = []
 const-generics = []
+force-scalar = []
 
 [dev-dependencies]
 rand = "0.8"

--- a/src/imp/mod.rs
+++ b/src/imp/mod.rs
@@ -1,8 +1,13 @@
+#[cfg(not(feature = "force-scalar"))]
 pub mod avx2;
+#[cfg(not(feature = "force-scalar"))]
 pub mod avx512;
 pub mod scalar;
+#[cfg(not(feature = "force-scalar"))]
 pub mod sse2;
+#[cfg(not(feature = "force-scalar"))]
 pub mod ssse3;
+#[cfg(not(feature = "force-scalar"))]
 pub mod wasm;
 
 pub type Adler32Imp = fn(u16, u16, &[u8]) -> (u16, u16);
@@ -14,10 +19,13 @@ pub const fn _MM_SHUFFLE(z: u32, y: u32, x: u32, w: u32) -> i32 {
 }
 
 pub fn get_imp() -> Adler32Imp {
-  avx512::get_imp()
+  #[cfg(feature = "force-scalar")]
+  return scalar::update;
+  #[cfg(not(feature = "force-scalar"))]
+  return avx512::get_imp()
     .or_else(avx2::get_imp)
     .or_else(ssse3::get_imp)
     .or_else(sse2::get_imp)
     .or_else(wasm::get_imp)
-    .unwrap_or(scalar::update)
+    .unwrap_or(scalar::update);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,8 +28,8 @@
 //! adler.write(b"rust is pretty cool, man");
 //! let hash = adler.finish();
 //!
-//! println!("{}", hash);
-//! // 1921255656
+//! println!("{}", hash); // 1921255656
+//! # assert_eq!(hash, 1921255656);
 //! ```
 //!
 //! ## Feature flags
@@ -164,7 +164,8 @@ impl Adler32 {
 /// use simd_adler32::adler32;
 ///
 /// let hash = adler32(b"Adler-32");
-/// println!("{}", hash); // 800813569
+/// println!("{}", hash); // 204735099
+/// # assert_eq!(hash, 204735099);
 /// ```
 pub fn adler32<H: Adler32Hash>(hash: &H) -> u32 {
   hash.hash()
@@ -198,7 +199,8 @@ pub mod read {
   //! let mut reader = Cursor::new(b"Hello there");
   //! let hash = adler32(&mut reader).unwrap();
   //!
-  //! println!("{}", hash) // 800813569
+  //! println!("{}", hash); // 409338925
+  //! # assert_eq!(hash, 409338925);
   //! ```
   use crate::Adler32;
   use std::io::{Read, Result};
@@ -213,7 +215,8 @@ pub mod read {
   /// let mut reader = Cursor::new(b"Hello there");
   /// let hash = adler32(&mut reader).unwrap();
   ///
-  /// println!("{}", hash) // 800813569
+  /// println!("{}", hash); // 409338925
+  /// # assert_eq!(hash, 409338925);
   /// ```
   pub fn adler32<R: Read>(reader: &mut R) -> Result<u32> {
     let mut hash = Adler32::new();
@@ -246,7 +249,8 @@ pub mod bufread {
   //! let mut reader = BufReader::new(reader);
   //! let hash = adler32(&mut reader).unwrap();
   //!
-  //! println!("{}", hash) // 800813569
+  //! println!("{}", hash); // 409338925
+  //! # assert_eq!(hash, 409338925);
   //! ```
   use crate::Adler32;
   use std::io::{BufRead, ErrorKind, Result};
@@ -262,7 +266,8 @@ pub mod bufread {
   /// let mut reader = BufReader::new(reader);
   /// let hash = adler32(&mut reader).unwrap();
   ///
-  /// println!("{}", hash) // 800813569
+  /// println!("{}", hash); // 409338925
+  /// # assert_eq!(hash, 409338925);
   /// ```
   pub fn adler32<R: BufRead>(reader: &mut R) -> Result<u32> {
     let mut hash = Adler32::new();


### PR DESCRIPTION
Reasoning: tools like `cargo clif` don't support the full expanse of `core::arch`.

This PR adds a feature to disable the simd part of this crate.

Also, just by the way, I saw a sizeable performance improvement when using `array_chunks` in `avx2.rs`.

Originally I planned to make use of `std::simd`, but that proved to be difficult.
