### PR TITLE
Fix build on latest nightlies when using the `nightly` feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@
 //!
 //! Feature detection tries to use the fastest supported feature first.
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(feature = "nightly", feature(stdsimd, avx512_target_feature))]
+#![cfg_attr(feature = "nightly", feature(stdarch_x86_avx512, avx512_target_feature))]
 
 #[doc(hidden)]
 pub mod hash;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,10 @@
 //!
 //! Feature detection tries to use the fastest supported feature first.
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(feature = "nightly", feature(stdarch_x86_avx512, avx512_target_feature))]
+#![cfg_attr(
+  all(feature = "nightly", any(target_arch = "x86", target_arch = "x86_64")),
+  feature(stdarch_x86_avx512, avx512_target_feature)
+)]
 
 #[doc(hidden)]
 pub mod hash;


### PR DESCRIPTION
As described in https://github.com/mcountryman/simd-adler32/issues/15, the `stdsimd` feature was removed.

I have tested that these changes do not introduce any behavior changes by running the defined unit tests.

Resolves #15.