### PR TITLE
Fix `wasm32` + `#[no_std]` compatibility

### DIFF
--- a/src/imp/wasm.rs
+++ b/src/imp/wasm.rs
@@ -143,7 +143,7 @@ mod imp {
 
   #[inline(always)]
   fn reduce_add(v: v128) -> u32 {
-    let arr: [u32; 4] = unsafe { std::mem::transmute(v) };
+    let arr: [u32; 4] = unsafe { core::mem::transmute(v) };
     let mut sum = 0u32;
     for val in arr {
       sum = sum.wrapping_add(val);


### PR DESCRIPTION
When using `simd-adler32` against a `wasm32-unknown-*` target in a `#[no_std]` context (e.g. with `default-features = false` specified for `simd-adler32`), an instance of `std` in `wasm.rs` causes this build to fail. This PR changes `std::mem::transmute` in this file to instead import from `core` so wasm/no_std are compatible.