### PR TITLE
Add avx512 feature to make AVX-512 usable on stable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,11 @@ path = "bench/variants.rs"
 harness = false
 
 [features]
-default = ["std", "const-generics"]
+default = ["std", "const-generics", "avx512"]
 std = []
 nightly = []
 const-generics = []
+avx512 = [] # Requires Rust 1.89 or later
 
 [dev-dependencies]
 rand = "0.8"

--- a/src/imp/avx512.rs
+++ b/src/imp/avx512.rs
@@ -8,7 +8,7 @@ pub fn get_imp() -> Option<Adler32Imp> {
 #[inline]
 #[cfg(all(
   feature = "std",
-  feature = "nightly",
+  any(feature = "nightly", feature = "avx512"),
   any(target_arch = "x86", target_arch = "x86_64")
 ))]
 fn get_imp_inner() -> Option<Adler32Imp> {
@@ -24,7 +24,7 @@ fn get_imp_inner() -> Option<Adler32Imp> {
 
 #[inline]
 #[cfg(all(
-  feature = "nightly",
+  any(feature = "nightly", feature = "avx512"),
   all(target_feature = "avx512f", target_feature = "avx512bw"),
   not(all(feature = "std", any(target_arch = "x86", target_arch = "x86_64")))
 ))]
@@ -34,10 +34,10 @@ fn get_imp_inner() -> Option<Adler32Imp> {
 
 #[inline]
 #[cfg(all(
-  not(all(feature = "nightly", target_feature = "avx512f", target_feature = "avx512bw")),
+  not(all(any(feature = "nightly", feature = "avx512"), target_feature = "avx512f", target_feature = "avx512bw")),
   not(all(
     feature = "std",
-    feature = "nightly",
+    any(feature = "nightly", feature = "avx512"),
     any(target_arch = "x86", target_arch = "x86_64")
   ))
 ))]
@@ -46,7 +46,7 @@ fn get_imp_inner() -> Option<Adler32Imp> {
 }
 
 #[cfg(all(
-  feature = "nightly",
+  any(feature = "nightly", feature = "avx512"),
   any(target_arch = "x86", target_arch = "x86_64"),
   any(
     feature = "std",


### PR DESCRIPTION
AVX-512 has been stable since Rust 1.89

Preserves the nightly feature behavior to avoid disabling AVX-512 for existing nightly users, e.g. Chromium