### PR TITLE
Add avx512_vnni implementation

### DIFF
--- a/bench/variants.rs
+++ b/bench/variants.rs
@@ -3,13 +3,17 @@ use criterion::{
   Criterion, Throughput,
 };
 use rand::{thread_rng, RngCore};
-use simd_adler32::imp::{avx2, avx512, scalar, sse2, ssse3, wasm, Adler32Imp};
+use simd_adler32::imp::{avx2, avx512, avx512_vnni, scalar, sse2, ssse3, wasm, Adler32Imp};
 
 pub fn bench(c: &mut Criterion) {
   let mut data = [0; 100_000];
   let mut group = c.benchmark_group("variants");
 
   thread_rng().fill_bytes(&mut data[..]);
+
+  if let Some(update) = avx512_vnni::get_imp() {
+    bench_variant(&mut group, "avx512_vnni", &data, update);
+  }
 
   if let Some(update) = avx512::get_imp() {
     bench_variant(&mut group, "avx512", &data, update);

--- a/src/imp/avx512_vnni.rs
+++ b/src/imp/avx512_vnni.rs
@@ -1,0 +1,255 @@
+use super::Adler32Imp;
+
+/// Resolves update implementation if CPU supports avx512f, avx512bw, and avx512vnni instructions.
+pub fn get_imp() -> Option<Adler32Imp> {
+  get_imp_inner()
+}
+
+#[inline]
+#[cfg(all(
+  feature = "std",
+  feature = "nightly",
+  any(target_arch = "x86", target_arch = "x86_64")
+))]
+fn get_imp_inner() -> Option<Adler32Imp> {
+  let has_avx512f = std::is_x86_feature_detected!("avx512f");
+  let has_avx512bw = std::is_x86_feature_detected!("avx512bw");
+  let has_avx512vnni = std::is_x86_feature_detected!("avx512vnni");
+
+  if has_avx512f && has_avx512bw && has_avx512vnni {
+    Some(imp::update)
+  } else {
+    None
+  }
+}
+
+#[inline]
+#[cfg(all(
+  feature = "nightly",
+  all(
+    target_feature = "avx512f",
+    target_feature = "avx512bw",
+    target_feature = "avx512vnni"
+  ),
+  not(all(feature = "std", any(target_arch = "x86", target_arch = "x86_64")))
+))]
+fn get_imp_inner() -> Option<Adler32Imp> {
+  Some(imp::update)
+}
+
+#[inline]
+#[cfg(all(
+  not(all(
+    feature = "nightly",
+    target_feature = "avx512f",
+    target_feature = "avx512bw",
+    target_feature = "avx512vnni"
+  )),
+  not(all(
+    feature = "std",
+    feature = "nightly",
+    any(target_arch = "x86", target_arch = "x86_64")
+  ))
+))]
+fn get_imp_inner() -> Option<Adler32Imp> {
+  None
+}
+
+#[cfg(all(
+  feature = "nightly",
+  any(target_arch = "x86", target_arch = "x86_64"),
+  any(
+    feature = "std",
+    all(
+      target_feature = "avx512f",
+      target_feature = "avx512bw",
+      target_feature = "avx512vnni"
+    )
+  )
+))]
+mod imp {
+  const MOD: u32 = 65521;
+  const NMAX: usize = 5552;
+  const BLOCK_SIZE: usize = 64;
+  const CHUNK_SIZE: usize = NMAX / BLOCK_SIZE * BLOCK_SIZE;
+
+  #[cfg(target_arch = "x86")]
+  use core::arch::x86::*;
+  #[cfg(target_arch = "x86_64")]
+  use core::arch::x86_64::*;
+
+  pub fn update(a: u16, b: u16, data: &[u8]) -> (u16, u16) {
+    unsafe { update_imp(a, b, data) }
+  }
+
+  #[inline]
+  #[target_feature(enable = "avx512f")]
+  #[target_feature(enable = "avx512bw")]
+  #[target_feature(enable = "avx512vnni")]
+  unsafe fn update_imp(a: u16, b: u16, data: &[u8]) -> (u16, u16) {
+    let mut a = a as u32;
+    let mut b = b as u32;
+
+    let chunks = data.chunks_exact(CHUNK_SIZE);
+    let remainder = chunks.remainder();
+    for chunk in chunks {
+      update_chunk_block(&mut a, &mut b, chunk);
+    }
+
+    update_block(&mut a, &mut b, remainder);
+
+    (a as u16, b as u16)
+  }
+
+  #[inline]
+  unsafe fn update_chunk_block(a: &mut u32, b: &mut u32, chunk: &[u8]) {
+    debug_assert_eq!(
+      chunk.len(),
+      CHUNK_SIZE,
+      "Unexpected chunk size (expected {}, got {})",
+      CHUNK_SIZE,
+      chunk.len()
+    );
+
+    reduce_add_blocks(a, b, chunk);
+
+    *a %= MOD;
+    *b %= MOD;
+  }
+
+  #[inline]
+  unsafe fn update_block(a: &mut u32, b: &mut u32, chunk: &[u8]) {
+    debug_assert!(
+      chunk.len() <= CHUNK_SIZE,
+      "Unexpected chunk size (expected <= {}, got {})",
+      CHUNK_SIZE,
+      chunk.len()
+    );
+
+    for byte in reduce_add_blocks(a, b, chunk) {
+      *a += *byte as u32;
+      *b += *a;
+    }
+
+    *a %= MOD;
+    *b %= MOD;
+  }
+
+  #[inline(always)]
+  unsafe fn reduce_add_blocks<'a>(a: &mut u32, b: &mut u32, chunk: &'a [u8]) -> &'a [u8] {
+    if chunk.len() < BLOCK_SIZE {
+      return chunk;
+    }
+
+    let blocks = chunk.chunks_exact(BLOCK_SIZE);
+    let blocks_remainder = blocks.remainder();
+
+    let zero_v = _mm512_setzero_si512();
+    let weights = get_weights();
+
+    let p_v = (*a * blocks.len() as u32) as _;
+    let mut p_v = _mm512_set_epi32(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, p_v);
+    let mut a_v = _mm512_setzero_si512();
+    let mut b_v = _mm512_set_epi32(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, *b as _);
+
+    for block in blocks {
+      let block_ptr = block.as_ptr() as *const _;
+      let block = _mm512_loadu_si512(block_ptr);
+
+      p_v = _mm512_add_epi32(p_v, a_v);
+
+      a_v = _mm512_add_epi32(a_v, _mm512_sad_epu8(block, zero_v));
+      b_v = _mm512_dpbusd_epi32(b_v, block, weights);
+    }
+
+    b_v = _mm512_add_epi32(b_v, _mm512_slli_epi32(p_v, 6));
+
+    *a += reduce_add(a_v);
+    *b = reduce_add(b_v);
+
+    blocks_remainder
+  }
+
+  #[inline(always)]
+  unsafe fn reduce_add(v: __m512i) -> u32 {
+    let v: [__m256i; 2] = core::mem::transmute(v);
+
+    reduce_add_256(v[0]) + reduce_add_256(v[1])
+  }
+
+  #[inline(always)]
+  unsafe fn reduce_add_256(v: __m256i) -> u32 {
+    let v: [__m128i; 2] = core::mem::transmute(v);
+    let sum = _mm_add_epi32(v[0], v[1]);
+    let hi = _mm_unpackhi_epi64(sum, sum);
+
+    let sum = _mm_add_epi32(hi, sum);
+    let hi = _mm_shuffle_epi32(sum, crate::imp::_MM_SHUFFLE(2, 3, 0, 1));
+
+    let sum = _mm_add_epi32(sum, hi);
+    let sum = _mm_cvtsi128_si32(sum) as _;
+
+    sum
+  }
+
+  #[inline(always)]
+  unsafe fn get_weights() -> __m512i {
+    _mm512_set_epi8(
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+      24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44,
+      45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64,
+    )
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use rand::Rng;
+
+  #[test]
+  fn zeroes() {
+    assert_sum_eq(&[]);
+    assert_sum_eq(&[0]);
+    assert_sum_eq(&[0, 0]);
+    assert_sum_eq(&[0; 100]);
+    assert_sum_eq(&[0; 1024]);
+    assert_sum_eq(&[0; 1024 * 1024]);
+  }
+
+  #[test]
+  fn ones() {
+    assert_sum_eq(&[]);
+    assert_sum_eq(&[1]);
+    assert_sum_eq(&[1, 1]);
+    assert_sum_eq(&[1; 100]);
+    assert_sum_eq(&[1; 1024]);
+    assert_sum_eq(&[1; 1024 * 1024]);
+  }
+
+  #[test]
+  fn random() {
+    let mut random = [0; 1024 * 1024];
+    rand::thread_rng().fill(&mut random[..]);
+
+    assert_sum_eq(&random[..1]);
+    assert_sum_eq(&random[..100]);
+    assert_sum_eq(&random[..1024]);
+    assert_sum_eq(&random[..1024 * 1024]);
+  }
+
+  /// Example calculation from https://en.wikipedia.org/wiki/Adler-32.
+  #[test]
+  fn wiki() {
+    assert_sum_eq(b"Wikipedia");
+  }
+
+  fn assert_sum_eq(data: &[u8]) {
+    if let Some(update) = super::get_imp() {
+      let (a, b) = update(1, 0, data);
+      let left = u32::from(b) << 16 | u32::from(a);
+      let right = adler::adler32_slice(data);
+
+      assert_eq!(left, right, "len({})", data.len());
+    }
+  }
+}

--- a/src/imp/mod.rs
+++ b/src/imp/mod.rs
@@ -1,5 +1,6 @@
 pub mod avx2;
 pub mod avx512;
+pub mod avx512_vnni;
 pub mod scalar;
 pub mod sse2;
 pub mod ssse3;
@@ -14,7 +15,8 @@ pub const fn _MM_SHUFFLE(z: u32, y: u32, x: u32, w: u32) -> i32 {
 }
 
 pub fn get_imp() -> Adler32Imp {
-  avx512::get_imp()
+  avx512_vnni::get_imp()
+    .or_else(avx512::get_imp)
     .or_else(avx2::get_imp)
     .or_else(ssse3::get_imp)
     .or_else(sse2::get_imp)


### PR DESCRIPTION
Since this adds a new file with minimal changes compared to avx512.rs, this is best reviewed with `diff src/imp/avx512.rs  src/imp/avx512_vnni.rs`

Addresses #22

On desktop Zen4 the improvements are marginal: there's a slight boost for the 10k benchmark and a proportionate regression for the 100k benchmark.