### PR TITLE
Enable stdarch_arm_neon_intrinsics on nightly arm

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,10 @@
   feature(stdarch_x86_avx512, avx512_target_feature)
 )]
 #![cfg_attr(
+  all(feature = "nightly", target_arch = "arm"),
+  feature(stdarch_arm_neon_intrinsics)
+)]
+#![cfg_attr(
   all(
     feature = "nightly",
     target_arch = "wasm64",


### PR DESCRIPTION
This allows the neon implementation to compile on 32-bit arm when the nightly feature is enabled, resolving E0658 errors for unstable intrinsics.