### PR TITLE
test with miri on neon

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -186,6 +186,8 @@ jobs:
           cargo miri setup
       - name: Run scalar tests under miri
         run: cargo +nightly miri test scalar
+      - name: Run neon tests under miri
+        run: cargo +nightly miri test --lib neon --target=aarch64-unknown-linux-gnu
       - name: Run sse2 tests under miri
         run: cargo +nightly miri test sse2
       - name: Run ssse3 tests under miri

--- a/src/imp/neon.rs
+++ b/src/imp/neon.rs
@@ -159,6 +159,8 @@ mod tests {
     assert_sum_eq(&[0, 0]);
     assert_sum_eq(&[0; 100]);
     assert_sum_eq(&[0; 1024]);
+    assert_sum_eq(&[0; 1024 - 5]);
+    #[cfg(not(miri))]
     assert_sum_eq(&[0; 1024 * 1024]);
   }
 
@@ -169,18 +171,26 @@ mod tests {
     assert_sum_eq(&[1, 1]);
     assert_sum_eq(&[1; 100]);
     assert_sum_eq(&[1; 1024]);
+    assert_sum_eq(&[1; 1024 - 5]); // non-power-of-2 to test remainder handling
+    #[cfg(not(miri))]
     assert_sum_eq(&[1; 1024 * 1024]);
   }
 
   #[test]
   fn random() {
-    let mut random = [0; 1024 * 1024];
+    // don't do any work if we're not on this target
+    if super::get_imp().is_none() {
+      return;
+    }
+
+    let mut random = [0; 1024 * 10];
     SmallRng::from_entropy().fill(&mut random[..]);
 
     assert_sum_eq(&random[..1]);
     assert_sum_eq(&random[..100]);
     assert_sum_eq(&random[..1024]);
-    assert_sum_eq(&random[..1024 * 1024]);
+    assert_sum_eq(&random[..1024 - 5]); // non-power-of-2 to test remainder handling
+    assert_sum_eq(&random[..1024 * 10]);
   }
 
   /// Example calculation from https://en.wikipedia.org/wiki/Adler-32.


### PR DESCRIPTION
I've been adding AArch64 instruction support for Miri recently, so the adler32 neon implementation now runs with Miri and we can test that in CI.

I've also updated the tests based on the avx512 tests.