### PR TITLE
Use native arm GitHub Actions runners

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,6 +46,9 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             toolchain: stable
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            toolchain: stable
           - os: macos-26-intel
             target: x86_64-apple-darwin
             toolchain: stable
@@ -65,6 +68,9 @@ jobs:
             toolchain: nightly
           - os: macos-latest
             target: aarch64-apple-darwin
+            toolchain: nightly
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
             toolchain: nightly
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
@@ -119,13 +125,7 @@ jobs:
             target: arm-unknown-linux-gnueabi
             toolchain: stable
           - os: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
-            toolchain: stable
-          - os: ubuntu-latest
             target: arm-unknown-linux-gnueabi
-            toolchain: nightly
-          - os: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
             toolchain: nightly
 
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,10 +46,12 @@ jobs:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             toolchain: stable
-          - os: macos-latest
+          - os: macos-26-intel
             target: x86_64-apple-darwin
             toolchain: stable
-            # TODO: also aarch64 / M1
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            toolchain: stable
           - os: windows-latest
             target: x86_64-pc-windows-gnu
             toolchain: stable
@@ -60,6 +62,9 @@ jobs:
           - os: ubuntu-latest
             deps: sudo apt-get update ; sudo apt install gcc-multilib
             target: i686-unknown-linux-gnu
+            toolchain: nightly
+          - os: macos-latest
+            target: aarch64-apple-darwin
             toolchain: nightly
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu


### PR DESCRIPTION
Two commits in this PR:

1. Add CI testing for aarch64 on macOS for both nightly and stable. Also moves the Intel test to a native Intel runner. (GitHub's default changed at some point)
2. Move the existing aarch64 tests on ubuntu from cross compilation to a native arm runner.