### PR TITLE
Make AVX512 available on stable rustc with a new feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,9 @@ harness = false
 [features]
 default = ["std", "const-generics"]
 std = []
-nightly = []
-const-generics = []
+nightly = ["avx512"]
+const-generics = [] # Requires Rust 1.51 or later
+avx512 = [] # Requires Rust 1.89 or later
 
 [dev-dependencies]
 rand = { version = "0.8", features = ["small_rng"] }

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ println!("{}", hash);
 | ✅   | `arm`, `aarch64` | neon    |
 | ✅   | `wasm32`         | simd128 |
 
+AVX512 support requires at least rustc `1.89`. To enable AVX512 support add the `avx512` feature.
+
 **MSRV** `1.36.0`\*\*
 
 Minimum supported rust version is tested before a new version is published. [**] Feature

--- a/src/imp/avx512.rs
+++ b/src/imp/avx512.rs
@@ -1,6 +1,6 @@
 use super::Adler32Imp;
 
-/// Resolves update implementation if CPU supports avx512f and avx512bw instructions.
+/// Resolves update implementation if CPU supports avx512bw instructions.
 pub fn get_imp() -> Option<Adler32Imp> {
   get_imp_inner()
 }
@@ -8,14 +8,11 @@ pub fn get_imp() -> Option<Adler32Imp> {
 #[inline]
 #[cfg(all(
   feature = "std",
-  feature = "nightly",
+  feature = "avx512",
   any(target_arch = "x86", target_arch = "x86_64")
 ))]
 fn get_imp_inner() -> Option<Adler32Imp> {
-  let has_avx512f = std::is_x86_feature_detected!("avx512f");
-  let has_avx512bw = std::is_x86_feature_detected!("avx512bw");
-
-  if has_avx512f && has_avx512bw {
+  if std::is_x86_feature_detected!("avx512bw") {
     Some(imp::update)
   } else {
     None
@@ -24,8 +21,8 @@ fn get_imp_inner() -> Option<Adler32Imp> {
 
 #[inline]
 #[cfg(all(
-  feature = "nightly",
-  all(target_feature = "avx512f", target_feature = "avx512bw"),
+  feature = "avx512",
+  target_feature = "avx512bw",
   not(all(feature = "std", any(target_arch = "x86", target_arch = "x86_64")))
 ))]
 fn get_imp_inner() -> Option<Adler32Imp> {
@@ -34,10 +31,10 @@ fn get_imp_inner() -> Option<Adler32Imp> {
 
 #[inline]
 #[cfg(all(
-  not(all(feature = "nightly", target_feature = "avx512f", target_feature = "avx512bw")),
+  not(all(feature = "avx512", target_feature = "avx512bw")),
   not(all(
     feature = "std",
-    feature = "nightly",
+    feature = "avx512",
     any(target_arch = "x86", target_arch = "x86_64")
   ))
 ))]
@@ -46,12 +43,9 @@ fn get_imp_inner() -> Option<Adler32Imp> {
 }
 
 #[cfg(all(
-  feature = "nightly",
+  feature = "avx512",
   any(target_arch = "x86", target_arch = "x86_64"),
-  any(
-    feature = "std",
-    all(target_feature = "avx512f", target_feature = "avx512bw")
-  )
+  any(feature = "std", target_feature = "avx512bw")
 ))]
 mod imp {
   const MOD: u32 = 65521;
@@ -69,7 +63,6 @@ mod imp {
   }
 
   #[inline]
-  #[target_feature(enable = "avx512f")]
   #[target_feature(enable = "avx512bw")]
   unsafe fn update_imp(a: u16, b: u16, data: &[u8]) -> (u16, u16) {
     let mut a = a as u32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,9 +38,14 @@
 //!
 //! Enables std support, see [CPU Feature Detection](#cpu-feature-detection) for runtime
 //! detection support.
+//!
+//! * `avx512`
+//!
+//! Enables avx512 support. Requires rustc ``>=1.89.0``.
+//!
 //! * `nightly`
 //!
-//! Enables nightly features required for avx512 support.
+//! Enables nightly features required for 32-bit arm neon support.
 //!
 //! * `const-generics` - Enabled by default
 //!
@@ -77,10 +82,6 @@
 //!
 //! Feature detection tries to use the fastest supported feature first.
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(
-  all(feature = "nightly", any(target_arch = "x86", target_arch = "x86_64")),
-  feature(stdarch_x86_avx512, avx512_target_feature)
-)]
 #![cfg_attr(
   all(feature = "nightly", target_arch = "arm"),
   feature(stdarch_arm_neon_intrinsics)


### PR DESCRIPTION
Alternative approach to #23.

Besides some additional documentation and cleanup the main differences are:

1. Eliminating any checks for `avx512f` as `avx512bw` [implies](https://github.com/rust-lang/rust/blob/3bf5c6d99bc8a0c0d5b2f69826ed4f6d256a0a21/compiler/rustc_target/src/target_features.rs#L432) its presence.
2. Making the `avx512` feature part of `nightly` instead of separately checking for both in code.
3. Making `avx512` opt-in (instead of opt-out in #23) so this can be released without backwards compatibility issues.

Closes #23