### PR TITLE
Fix compiling on ARM with `target_feature = "neon"`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -127,6 +127,12 @@ jobs:
           - os: ubuntu-latest
             target: arm-unknown-linux-gnueabi
             toolchain: nightly
+          - os: ubuntu-latest
+            target: thumbv7neon-unknown-linux-gnueabihf
+            toolchain: stable
+          - os: ubuntu-latest
+            target: thumbv7neon-unknown-linux-gnueabihf
+            toolchain: nightly
 
     steps:
       - uses: actions/checkout@v2

--- a/src/imp/neon.rs
+++ b/src/imp/neon.rs
@@ -1,16 +1,16 @@
 use super::Adler32Imp;
 
-#[cfg(target_feature = "neon")]
+#[cfg(all(target_feature = "neon", any(target_arch = "aarch64", feature = "nightly")))]
 pub fn get_imp() -> Option<Adler32Imp> {
   Some(imp::update)
 }
 
-#[cfg(not(target_feature = "neon"))]
+#[cfg(not(all(target_feature = "neon", any(target_arch = "aarch64", feature = "nightly"))))]
 pub fn get_imp() -> Option<Adler32Imp> {
   None
 }
 
-#[cfg(target_feature = "neon")]
+#[cfg(all(target_feature = "neon", any(target_arch = "aarch64", feature = "nightly")))]
 mod imp {
   const MOD: u32 = 65521;
   const NMAX: usize = 5552;


### PR DESCRIPTION
This currently requires the "nightly" Cargo feature, since it uses unstable functions in the `stdarch_arm_neon_intrinsics` feature. When the nightly feature is disabled, this should instead use the slower fallback implementation.

This wasn't caught by CI previously, because the tested target `arm-unknown-linux-gnueabi` does not have `target_feature = "neon"`. I've added a target to CI that does have this.

Example of a CI run that I've had fail because of this:
https://github.com/madsmtm/objc2/actions/runs/26403792559/job/77722198358

Introduced in https://github.com/mcountryman/simd-adler32/pull/26. Related to https://github.com/mcountryman/simd-adler32/pull/31.
