### PR TITLE
Fix/update GitHub Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,5 @@
 name: build
+permissions: {}
 
 on:
   push:
@@ -7,6 +8,8 @@ on:
 
 jobs:
   clippy:
+    permissions:
+      checks: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,7 @@ jobs:
           profile: minimal
           toolchain: nightly
           override: true
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - run: cargo install cargo-deadlinks
       - name: doc
         env:
@@ -86,7 +86,7 @@ jobs:
           target: ${{ matrix.target }}
           toolchain: ${{ matrix.toolchain }}
           override: true
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - run: ${{ matrix.deps }}
       - name: Maybe minimal versions
         if: ${{ matrix.variant == 'minimal_versions' }}
@@ -138,7 +138,7 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           override: true
 
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - name: Install cross
         run: cargo install cross || true
       - name: Test
@@ -154,7 +154,7 @@ jobs:
         with:
           target: x86_64-unknown-linux-gnu
           toolchain: 1.36.0 # MSRV
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - name: Test
         run: cargo test --target=x86_64-unknown-linux-gnu --no-default-features --features=std
 
@@ -169,7 +169,7 @@ jobs:
           toolchain: nightly
           target: thumbv6m-none-eabi
           override: true
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - name: Build top-level only
         run: cargo build --target=thumbv6m-none-eabi --no-default-features
 
@@ -183,7 +183,7 @@ jobs:
           profile: minimal
           toolchain: nightly
           override: true
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - name: Install Miri
         run: |
           rustup toolchain install nightly --component miri

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,7 +9,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v6
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
@@ -23,7 +23,7 @@ jobs:
   test-doc:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -78,7 +78,7 @@ jobs:
             variant: minimal_versions
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -129,7 +129,7 @@ jobs:
             toolchain: nightly
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -148,7 +148,7 @@ jobs:
   test-msrv:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -161,7 +161,7 @@ jobs:
   test-no-std:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -176,7 +176,7 @@ jobs:
   test-miri:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
@@ -27,6 +29,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -82,6 +86,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -133,6 +139,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -152,6 +160,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -165,6 +175,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -180,6 +192,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -1,4 +1,5 @@
 name: fuzz
+permissions: {}
 
 on:
   schedule:

--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -30,7 +30,6 @@ jobs:
           toolchain: nightly
           override: true
 
-      - uses: Swatinem/rust-cache@v1
       - run: cargo install cargo-fuzz
 
       - name: Download corpus artifact

--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -24,6 +24,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: setup
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -22,7 +22,7 @@ jobs:
             target: neon
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: setup
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -2,6 +2,7 @@ name: fuzz
 permissions: {}
 
 on:
+  workflow_dispatch:
   schedule:
     # Run every 24h
     - cron: "0 0 * * *"

--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -47,14 +47,14 @@ jobs:
           cargo fuzz run ${{ matrix.target }} -- -max_total_time=1800
 
       - name: Archive artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: artifacts
           path: fuzz/artifacts
 
       # big decision.  do we store corpus from failed jobs?  for now we don't..
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v7
         with:
           name: corpus
           path: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,7 +8,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Configure git user
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,4 +1,6 @@
 name: publish
+permissions:
+  contents: write
 
 on:
   push:


### PR DESCRIPTION
I noticed a few issues with the GitHub Actions in the repository, including the fact that the fuzz action currently [doesn't run](https://github.com/mcountryman/simd-adler32/actions/workflows/fuzz.yaml).

This PR fixes that issues and makes a few other changes. Every change is a single commit. In case you disagree with a change, happy to revert that one. There are more outdated dependencies (and deprecation warnings) left after this but it should be a nice step forward.

